### PR TITLE
Issue with new webpack version on ios

### DIFF
--- a/advanced-webview.ios.ts
+++ b/advanced-webview.ios.ts
@@ -62,7 +62,7 @@ export function openAdvancedUrl(options: AdvancedWebViewOptions): void {
   }
 
   sfc.delegate = SFSafariViewControllerDelegateImpl.initWithOwnerCallback(
-    new WeakRef(this),
+    new WeakRef({}),
     options.isClosed
   );
 


### PR DESCRIPTION
Hi,

since last webpack update, when using the bundled version `this` is converted to `undefined` and Weakref breaks because an object needs to be injected to the parameters.
