### PR TITLE
point to the advanced webview with the 1.0.2 appcompat lib

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-advanced-webview",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An advanced webview using Chrome CustomTabs on Android and SFSafariViewController on iOS.",
   "main": "advanced-webview",
   "typings": "index.d.ts",

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -10,6 +10,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.github.triniwiz:fancy-advanced-webview:a9359d17f0'
+	implementation 'com.github.jamesroome:fancy-advanced-webview:c984b3f'
     implementation 'androidx.browser:browser:1.2.0'
 }


### PR DESCRIPTION
As [mentioned](https://github.com/NativeScript/NativeScript/issues/8298) by NickIliev the current version of the Android AppCompat library is 1.0.2 

I created a [fork](https://github.com/JamesRoome/fancy-advanced-webview) of fancy-advanced-webview that is using the correct version.

This solves my issue, I have been able to (finally!) update all my NativeScript libraries to latest.
